### PR TITLE
correct minimum required version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Bilateral Inceptions on Caffe
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 project(BilateralInceptions C CXX)
 
 cmake_policy(SET CMP0054 NEW)


### PR DESCRIPTION
CMake version 3.1 does not support the "continue" command, which is required here.